### PR TITLE
Ports and scans now operate on enums instead of ints.

### DIFF
--- a/server/HackThePlanet/Components/ComputerComponent.cs
+++ b/server/HackThePlanet/Components/ComputerComponent.cs
@@ -13,6 +13,6 @@ namespace HackThePlanet
 		public byte MaxRam;
 		public byte UsedRam;
 
-		public List<int> OpenPorts = new List<int>();
+		public List<Port> OpenPorts = new List<Port>();
 	}
 }

--- a/server/HackThePlanet/Components/PlayerComponent.cs
+++ b/server/HackThePlanet/Components/PlayerComponent.cs
@@ -48,6 +48,9 @@ namespace HackThePlanet
 			// TODO: Randomly generate IpAddress.
 			computerComponent.IpAddress = IPAddress.Parse("127.0.0.1").Address;
 			computerComponent.OpenPorts.Add(Port.Ssh);
+			computerComponent.OpenPorts.Add(Port.Ftp);
+			computerComponent.OpenPorts.Add(Port.Http);
+			computerComponent.OpenPorts.Add(Port.Ssl);
 			newEntity.AddComponent(computerComponent);
 
 			Console.Out.WriteLine($"Created new player: {playerComponent.Id}");

--- a/server/HackThePlanet/Components/PortScanComponent.cs
+++ b/server/HackThePlanet/Components/PortScanComponent.cs
@@ -8,6 +8,6 @@ namespace HackThePlanet
     {
         public int InitiatingEntity;
         public List<int> OpenPorts;
-        public int CurrentPort;
+        public Port CurrentPort;
     }
 }

--- a/server/HackThePlanet/Extensions/EnumExtensions.cs
+++ b/server/HackThePlanet/Extensions/EnumExtensions.cs
@@ -1,0 +1,29 @@
+namespace HackThePlanet
+{
+    using System;
+    using System.Linq;
+
+
+    public static class EnumExtensions
+    {
+        public static T GetLast<T>()
+            where T : struct
+        {
+            if (!typeof(T).IsEnum) 
+                throw new ArgumentException(String.Format("Argument {0} is not an Enum", typeof(T).FullName));
+            
+            return Enum.GetValues(typeof(T)).Cast<T>().Last();
+            
+        }
+
+
+        public static T Next<T>(this T src) where T : struct
+        {
+            if (!typeof(T).IsEnum) throw new ArgumentException(String.Format("Argument {0} is not an Enum", typeof(T).FullName));
+
+            T[] Arr = (T[])Enum.GetValues(src.GetType());
+            int j = Array.IndexOf<T>(Arr, src) + 1;
+            return (Arr.Length==j) ? Arr[0] : Arr[j];            
+        }
+    }
+}

--- a/server/HackThePlanet/Game.cs
+++ b/server/HackThePlanet/Game.cs
@@ -1,5 +1,6 @@
 namespace HackThePlanet
 {
+	using System.Threading;
 	using Microsoft.Extensions.Logging;
 	using PrimitiveEngine;
 
@@ -34,6 +35,7 @@ namespace HackThePlanet
 		public override void Update(long deltaTime)
 		{
 			this.entityWorld.FixedUpdate(deltaTime);
+			Thread.Sleep(15); // Fuck it, let's not get fancy here.
 		}
 	}
 }

--- a/server/HackThePlanet/GameService.cs
+++ b/server/HackThePlanet/GameService.cs
@@ -6,6 +6,7 @@ namespace HackThePlanet
 	using Microsoft.Extensions.Configuration;
 	using Microsoft.Extensions.Logging;
 	using Newtonsoft.Json;
+	using PrimitiveEngine;
 
 
 	/// <summary>
@@ -57,6 +58,12 @@ namespace HackThePlanet
 			get { return this.logger; }
 		}
 		#endregion
+
+
+		public static Entity GetEntity(int entityId)
+		{
+			return Game.EntityWorld.GetEntityById(entityId);
+		}
 
 
 		public void OnStart()

--- a/server/HackThePlanet/Port.cs
+++ b/server/HackThePlanet/Port.cs
@@ -1,7 +1,10 @@
 namespace HackThePlanet
 {
-    public static class Port
+    public enum Port : int
     {
-        public const int Ssh = 22;
+        Ftp = 21,
+        Ssh = 22,
+        Http = 80,
+        Ssl = 443
     }
 }

--- a/server/HackThePlanet/Systems/PortScanSystem.cs
+++ b/server/HackThePlanet/Systems/PortScanSystem.cs
@@ -24,9 +24,11 @@ namespace HackThePlanet.Systems
                 initiatingPlayer.AddTerminalMessage($"Found open port: {portScanComponent.CurrentPort}");
             }
 
-            portScanComponent.CurrentPort++;
-
-            if (portScanComponent.CurrentPort > MaxPort)
+            if (portScanComponent.CurrentPort != EnumExtensions.GetLast<Port>())
+            {
+                portScanComponent.CurrentPort++;
+            }
+            else
             {
                 initiatingPlayer.AddTerminalMessage($"Finished port scan of {computerComponent.IpAddress.ToIPString()}");
                 entity.RemoveComponent<PortScanComponent>();


### PR DESCRIPTION
Possible lazy hack for CPU grinding (yeah, yeah, I know, Thread.Sleep is bad).